### PR TITLE
Import maps as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ export type SingleSpaRootPluginOptions = {
     type: 'root';
     importMaps?: {
         type?: 'importmap' | 'overridable-importmap' | 'systemjs-importmap' | 'importmap-shim';
-        dev?: string | string[];
-        build?: string | string[];
+        dev?: string | string[] | Record<string, any>;
+        build?: string | string[] | Record<string, any>;
     };
     imo?: boolean | string | (() => string);
     imoUi?: boolean | 'full' | 'popup' | 'list' | {

--- a/src/plugin-factory.ts
+++ b/src/plugin-factory.ts
@@ -125,6 +125,9 @@ export function pluginFactory(readFileFn?: (path: string, options: any) => Promi
                 }) as string;
                 return [contents];
             }
+            else if (typeof fileCfg === 'object' && !Array.isArray(fileCfg)) {
+                return [JSON.stringify(fileCfg)];
+            }
             else {
                 const fileContents: string[] = [];
                 for (let f of fileCfg) {

--- a/src/vite-plugin-single-spa.d.ts
+++ b/src/vite-plugin-single-spa.d.ts
@@ -114,11 +114,11 @@ declare module "vite-plugin-single-spa" {
         /**
          * File name or array of file names of the import map or maps to be used while developing.
          */
-        dev?: string | string[];
+        dev?: string | string[] | Record<string, any>;
         /**
          * File name or array of file names of the import map or maps to be used while building.
          */
-        build?: string | string[];
+        build?: string | string[] | Record<string, any>;
     };
 
     /**


### PR DESCRIPTION
Implements the ability to pass importMaps as an object

Example:
```js
const baseUrl = '/foo'; // may by an environment variable
// ...
vitePluginSingleSpa({
  // ...
  importMaps: {
    type: 'importmap',
    dev: {
      imports: {
        '@learnSspa/spa01': 'http://localhost:4101/src/spa.ts',
        '@learnSspa/spa02': 'http://localhost:4102/src/spa.ts',
      },
    },
    build: {
      imports: {
        '@learnSspa/spa01': `${baseUrl}/spa01-prefix/spa.js`,
        '@learnSspa/spa02': `${baseUrl}/spa02-prefix/spa.js`,
      },
    },
  },
});
```