### PR TITLE
Add rollup's entryFileNames option

### DIFF
--- a/src/plugin-factory.ts
+++ b/src/plugin-factory.ts
@@ -178,7 +178,7 @@ export function pluginFactory(readFileFn?: (path: string, options: any) => Promi
             cfg.preview = {
                 port: plugInConfig.serverPort
             };
-            const entryFileNames = '[name].js';
+            const entryFileNames = plugInConfig.entryFileNames && '[name].js';
             const input: InputOption = {};
             let preserveEntrySignatures: PreserveEntrySignaturesOption;
             if (viteOpts.command === 'build') {

--- a/src/vite-plugin-single-spa.d.ts
+++ b/src/vite-plugin-single-spa.d.ts
@@ -100,6 +100,14 @@ declare module "vite-plugin-single-spa" {
          * `vpss(<project id>)<pattern>`.  The plug-in is smart enough to respect any folders in the pattern.
          */
         assetFileNames?: string;
+        /**
+         * Pattern that specifies how entry file names are constructed.  Its default value is 
+         * `[name].js`.
+         * 
+         * Refer to [Rollup's documentaiton](https://rollupjs.org/configuration-options/#output-entryfilenames) for 
+         * additional information.
+         */
+        entryFileNames?: string;
     } & DebuggingOptions;
 
     /**


### PR DESCRIPTION
This adds this ability to specify rollup's `entryFileNames` configuration for the plugin.

Sometimes I want my output to have a different name than my `spaEntryPoints`.
Example: spaEntryPoints is `"src/spa.tsx"` but I would like my output to be `src/index.tsx`.