### PR TITLE
feat: Allow Vite version 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "typescript": "^5.7.2"
       },
       "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/WJSoftware/vite-plugin-single-spa#readme",
   "peerDependencies": {
-    "vite": "^5.0.0 || ^6.0.0"
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "@types/chai": "^5.0.1",


### PR DESCRIPTION
Hello,

I would like to use single-spa with Vite 7. I have tested several configurations locally with Vite 7 (7.1.1) and did not encounter any problems. Test and build also run without any issues.

I would appreciate it if you could include this change in your repository. If you like, I'm also interested in testing the PRs from dependabot. However, I wanted to dedicate this PR specifically to Vite 7 so that it doesn't become too overloaded.

Thank you very much for your work!

Best regards,
Daniel