### PR TITLE
fix: Move CSS collection to generateBundle for Vite 6 & 7 compatibility

### DIFF
--- a/src/plugin-factory.ts
+++ b/src/plugin-factory.ts
@@ -350,29 +350,8 @@ export function pluginFactory(readFileFn?: (path: string, options: any) => Promi
                             logData += markdownCodeBlock(formatData("options: %o", options));
                             logData += markdownCodeBlock(formatData("meta: %o", meta));
                         }
-                        if (chunk.isEntry && !isRootConfig(config) && config.cssStrategy !== 'none') {
-                            // Recursively collect all CSS files that this entry point might need.
-                            const cssFiles = new Set<string>();
-                            const processedImports = new Set<string>();
-                            const collectCssFiles = (curChunk: RenderedChunk) => {
-                                if (!curChunk) {
-                                    return;
-                                }
-                                curChunk.viteMetadata?.importedCss.forEach(css => cssFiles.add(css));
-                                for (let imp of curChunk.imports) {
-                                    if (processedImports.has(imp)) {
-                                        continue;
-                                    }
-                                    processedImports.add(imp);
-                                    collectCssFiles(meta.chunks[imp]);
-                                }
-                            };
-                            collectCssFiles(chunk);
-                            cssMap[chunk.name] = [];
-                            for (let css of cssFiles.values()) {
-                                cssMap[chunk.name].push(css);
-                            }
-                        }
+                        // NOTE: CSS collection moved to generateBundle hook for Vite 7 compatibility.
+                        // In Vite 7, viteMetadata.importedCss is not populated until after renderChunk completes.
                     }
                     catch (error) {
                         errorOccurred = true;
@@ -391,6 +370,34 @@ export function pluginFactory(readFileFn?: (path: string, options: any) => Promi
                     await closeLog();
                 }
                 if (!isRootConfig(config) && config.cssStrategy !== 'none') {
+                    // Collect CSS files from entry chunks.
+                    // This is done here instead of renderChunk because in Vite 7,
+                    // viteMetadata.importedCss is not populated until after renderChunk.
+                    for (let x in bundle) {
+                        const chunk = bundle[x];
+                        if (chunk.type === 'chunk' && chunk.isEntry) {
+                            const cssFiles = new Set<string>();
+                            const processedImports = new Set<string>();
+                            const collectCssFiles = (curChunk: RenderedChunk) => {
+                                if (!curChunk) {
+                                    return;
+                                }
+                                curChunk.viteMetadata?.importedCss?.forEach(css => cssFiles.add(css));
+                                for (let imp of curChunk.imports || []) {
+                                    if (processedImports.has(imp)) {
+                                        continue;
+                                    }
+                                    processedImports.add(imp);
+                                    collectCssFiles(bundle[imp] as RenderedChunk);
+                                }
+                            };
+                            collectCssFiles(chunk);
+                            cssMap[chunk.name] = [];
+                            for (let css of cssFiles.values()) {
+                                cssMap[chunk.name].push(css);
+                            }
+                        }
+                    }
                     const stringifiedCssMap = JSON.stringify(JSON.stringify(cssMap));
                     for (let x in bundle) {
                         const entry = bundle[x];

--- a/tests/plugin-factory.test.ts
+++ b/tests/plugin-factory.test.ts
@@ -525,12 +525,21 @@ describe('vite-plugin-single-spa', () => {
             for (let ch of chunks) {
                 await (plugIn.renderChunk as RenderChunkHandler).handler('', ch, {}, meta);
             }
-            const bundle = {
+            // Build the bundle object with all chunks for generateBundle.
+            // In Vite 7+, CSS collection happens in generateBundle where viteMetadata.importedCss
+            // is fully populated, so the bundle must include all chunks with their metadata.
+            const bundle: Record<string, any> = {
                 'a.js': {
                     type: 'chunk',
                     code: '"{vpss:CSS_MAP}"'
                 }
             };
+            for (let ch of chunks) {
+                bundle[ch.fileName] = {
+                    ...ch,
+                    type: 'chunk'
+                };
+            }
 
             // Act.
             await (plugIn.generateBundle as GenerateBundleHandler)({}, bundle);


### PR DESCRIPTION
## Problem

In Vite 6 & 7, `chunk.viteMetadata.importedCss` is not populated when the `renderChunk` hook runs. This causes the CSS map to be empty, resulting in micro-frontend CSS not being loaded in production.

## Root Cause

The plugin currently collects CSS in the `renderChunk` hook, but Vite 6/7 only populates `viteMetadata.importedCss` after all `renderChunk` hooks have completed. When the plugin checks for CSS files, the metadata is still empty.

## Solution

Move CSS collection from the `renderChunk` hook to the `generateBundle` hook, where `viteMetadata.importedCss` is fully populated.

## Changes

- Removed CSS collection logic from `renderChunk` hook
- Added CSS collection logic to `generateBundle` hook before injecting the cssMap
- Added defensive null checks for `importedCss` and `imports` arrays
- Added explanatory comment about Vite 7 compatibility

## Testing

Verified with a monorepo containing 7+ micro-frontends on Vite 7.2.7:

**Before fix:**
```javascript
cssInjectedDictionary="{\"main\":[]}"
```

**After fix:**
```javascript
cssInjectedDictionary="{\"main\":[\"assets/vpss(@riskhub/actions-man)main-xxx.css\"]}"
```

All micro-frontend CSS now loads correctly in production builds.

## Related

This issue was mentioned in #87 where the workaround was to use `inlineDynamicImports: true`. This fix resolves the root cause, allowing proper code splitting while maintaining CSS loading.