### PR TITLE
feat: Support double and single quotation marks  when replacing vpss:CSS_MAP string

### DIFF
--- a/src/plugin-factory.ts
+++ b/src/plugin-factory.ts
@@ -404,7 +404,7 @@ export function pluginFactory(readFileFn?: (path: string, options: any) => Promi
                         if (entry.type === 'chunk') {
                             entry.code = entry.code
                                 ?.replace('{vpss:PROJECT_ID}', projectId)
-                                .replace('"{vpss:CSS_MAP}"', stringifiedCssMap);
+                                 .replace(/["`']\{vpss:CSS_MAP\}["`']/, stringifiedCssMap);
                         }
                     }
                 }

--- a/tests/plugin-factory.test.ts
+++ b/tests/plugin-factory.test.ts
@@ -515,7 +515,7 @@ describe('vite-plugin-single-spa', () => {
             // Assert.
             expect(caughtError).to.equal(false);
         });
-        const cssMapInsertionTest = async (chunks: TestRenderedChunk[], expectedMap: Record<string, string[]>) => {
+        const cssMapInsertionTest = async (chunks: TestRenderedChunk[], expectedMap: Record<string, string[]>, cssPlaceholderStr: string) => {
             // Arrange.
             const readFile = (fileName: string, _opts: any) => {
                 if (fileName !== './package.json') {
@@ -541,7 +541,7 @@ describe('vite-plugin-single-spa', () => {
             const bundle: Record<string, any> = {
                 'a.js': {
                     type: 'chunk',
-                    code: '"{vpss:CSS_MAP}"'
+                    code: cssPlaceholderStr,
                 }
             };
             for (let ch of chunks) {
@@ -819,7 +819,14 @@ describe('vite-plugin-single-spa', () => {
             },
         ];
         for (let tc of cssMapInsertionTestData) {
-            it(`Should insert the stringified CSS Map in chunks that need it: ${tc.text}`, () => cssMapInsertionTest(tc.chunks, tc.expectedMap));
+            for (let cssPlaceholderStr of ["'{vpss:CSS_MAP}'", "`{vpss:CSS_MAP}`", '"{vpss:CSS_MAP}"']) {
+                it(`Should insert the stringified CSS Map in chunks that need it: ${tc.text}; CSS_MAP placeholder: ${cssPlaceholderStr}`,
+                    () => cssMapInsertionTest(tc.chunks, tc.expectedMap, cssPlaceholderStr));
+            }
+            for (let cssInvalidPlaceholderStr of ["<{vpss:CSS_MAP}>", "{vpss:CSS_MAP}"]) {
+                it.fails(`Should not insert the stringified CSS Map in chunks with an invalid placeholder: ${tc.text}; CSS_MAP placeholder: ${cssInvalidPlaceholderStr}`,
+                    () => cssMapInsertionTest(tc.chunks, tc.expectedMap, cssInvalidPlaceholderStr));
+            }
         }
         it("Should insert the package's name in the chunks that require it.", async () => {
             // Arrange.


### PR DESCRIPTION
Hi @webJose, I ran into a bug where a vite plugin was changing the quotation marks in the css template file (`multiMife-css.ts`) from `"{vpss:CSS_MAP}"` to \`{vpss:CSS_MAP}\`. As a consequence the replace function did not match it.

This PR changes the replace function call from `replace('"{vpss:CSS_MAP}"',stringifiedCssMap)` to  .replace(/["\`']\{vpss:CSS_MAP\}["\`']/, stringifiedCssMap).

I know you are not actively maintaining the project anymore. Let me know if you want to merge/release it, I'll create a fork otherwise :)