### PR TITLE
feat: support for path-based cssLifecycleFactory entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ export const unmount = [cssLc.unmount, lc.unmount];
 
 The lifecycle factory algorithm needs to know which entry point it should be creating the lifecycle object for, so it 
 is very important that the name passed to the factory coincides *exactly* with the file name (minus the extension).
+To prevent collisions when exporting multiple entryPoints with the same file name, you can set the plugin option
+`useRelativePathForLifecycleIdentifiers` to true, when you call `vitePluginSingleSpa` in the vite config.
 
 The object created by the factory (in the example, stored in the `cssLc` variable), **must** be used for every 
 exported/created `single-spa` lifecycle object that comes out of the same file (module).

--- a/README.md
+++ b/README.md
@@ -339,18 +339,16 @@ const lc = singleSpaReact({
         return <div>Error: {err}</div>
     }
 });
-// IMPORTANT:  Because the file is named spa.tsx, the string 'spa'
-// must be passed to the call to cssLifecycleFactory.
-const cssLc = cssLifecycleFactory('spa', /* optional factory options */);
+// If only one entry point with the file name `spa.*` exists, you can also just pass "spa".
+const cssLc = cssLifecycleFactory('src/spa.tsx', /* optional factory options */);
 export const bootstrap = [cssLc.bootstrap, lc.bootstrap];
 export const mount = [cssLc.mount, lc.mount];
 export const unmount = [cssLc.unmount, lc.unmount];
 ```
 
-The lifecycle factory algorithm needs to know which entry point it should be creating the lifecycle object for, so it 
-is very important that the name passed to the factory coincides *exactly* with the file name (minus the extension).
-To prevent collisions when exporting multiple entryPoints with the same file name, you can set the plugin option
-`useRelativePathForLifecycleIdentifiers` to true, when you call `vitePluginSingleSpa` in the vite config.
+The lifecycle factory algorithm needs to know which entry point it should be creating the lifecycle object for.
+So you need to pass it the path to the entry point. If only one entry point with your file name exists, you can also
+use the file name without extension.
 
 The object created by the factory (in the example, stored in the `cssLc` variable), **must** be used for every 
 exported/created `single-spa` lifecycle object that comes out of the same file (module).

--- a/src/css-helpers.ts
+++ b/src/css-helpers.ts
@@ -174,3 +174,43 @@ export async function processCssPromises(
         }
     }
 }
+
+/**
+ * Takes an entry point string passed to `cssLifecycleFactory` and matches it with the css map.
+ * The entry point string may be the filename without extension or the pathname relative to the project root.
+ *
+ * @param entryPointId The entry point file name, or path to it.
+ * @param cssMap The css map that as keys has the relative paths of all entry points and as values the associated css files..
+ */
+export function getCssFilesForEntrypoint(
+    entryPointId: string,
+    cssMap: Record<string, string[]>,
+) {
+    // Normalize the input by removing leading './'
+    let resolvedEntryPoint = entryPointId.startsWith("./")
+        ? entryPointId.substring(2)
+        : entryPointId;
+
+    const keys = Object.keys(cssMap).filter((entryPath) => {
+        const entryWithoutExt = entryPath
+            .replace(/^.*[\\/]/, "")
+            .replace(/\.[^.]+$/, "");
+
+        // Exact match (with or without extension)
+        if (
+            entryPath === resolvedEntryPoint ||
+            entryWithoutExt === resolvedEntryPoint
+        ) {
+            return true;
+        }
+
+        return false;
+    });
+
+    if (keys.length > 1) {
+        throw new Error(
+            `The given entry point ${entryPointId} matched more than one entry point file: [${keys}]. Use the path instead, to distinguish them.`,
+        );
+    }
+    return keys.length > 0 ? cssMap[keys[0]] : [];
+}

--- a/src/ex.d.ts
+++ b/src/ex.d.ts
@@ -68,8 +68,9 @@ declare module 'vite-plugin-single-spa/ex' {
      * Note that there is no need to call this multiple times if the entry point is the same.  In other words:  The 
      * returned object can be used for the lifecycles of many `single-spa` micro-frontends/parcels as long as they are 
      * exported from the same entry point file.
-     * @param entryPoint Name of the entry point that dictates which CSS files the CSS lifecycle object will be 
-     * managing.
+     * @param entryPoint The path to the entry point file or just the entry point file name without extension.
+     * In case there is more than one entry point with the same file name, you must use the path.
+     * The entry point dictates which CSS files the CSS lifecycle object will be managing.
      * @param options CSS lifecycle factory options.
      * @returns The `single-spa` lifecycle object capable of managing the entry point's CSS files.
      */

--- a/src/multiMife-css.ts
+++ b/src/multiMife-css.ts
@@ -19,7 +19,8 @@ export function cssLifecycleFactory(entryPoint: string, options?: CssLifecycleFa
         ...options
     };
     setLogger(opts.logger);
-    const cssFileNames = cssMap[entryPoint] ?? [];
+    let resolvedEntryPoint = entryPoint.startsWith("./") ? entryPoint.substring(2) : entryPoint;
+    const cssFileNames = cssMap[resolvedEntryPoint] ?? [];
 
     return {
         bootstrap,

--- a/src/multiMife-css.ts
+++ b/src/multiMife-css.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 import { type CssLifecycleFactoryOptions } from "vite-plugin-single-spa/ex";
-import { createLinkElement, defaultFactoryOptions, getLogger, processCssPromises, setLogger, wireCssLinkElement, type LinkLoadResult } from "./css-helpers.js";
+import { createLinkElement, defaultFactoryOptions, getCssFilesForEntrypoint, getLogger, processCssPromises, setLogger, wireCssLinkElement, type LinkLoadResult } from "./css-helpers.js";
 
 let observer: MutationObserver | undefined;
 let autoLinkEls: HTMLLinkElement[] = [];
@@ -19,8 +19,8 @@ export function cssLifecycleFactory(entryPoint: string, options?: CssLifecycleFa
         ...options
     };
     setLogger(opts.logger);
-    let resolvedEntryPoint = entryPoint.startsWith("./") ? entryPoint.substring(2) : entryPoint;
-    const cssFileNames = cssMap[resolvedEntryPoint] ?? [];
+
+    const cssFileNames = getCssFilesForEntrypoint(entryPoint, cssMap);
 
     return {
         bootstrap,

--- a/src/plugin-factory.ts
+++ b/src/plugin-factory.ts
@@ -388,21 +388,21 @@ export function pluginFactory(readFileFn?: (path: string, options: any) => Promi
                             const processedImports = new Set<string>();
                             const collectCssFiles = (curChunk: Rollup.RenderedChunk) => {
                                 if (!curChunk) {
-                                return;
+                                    return;
                                 }
                                 curChunk.viteMetadata?.importedCss?.forEach(css => cssFiles.add(css));
                                 for (let imp of curChunk.imports || []) {
-                                if (processedImports.has(imp)) {
-                                    continue;
-                                }
-                                processedImports.add(imp);
+                                    if (processedImports.has(imp)) {
+                                        continue;
+                                    }
+                                    processedImports.add(imp);
                                     collectCssFiles(bundle[imp] as Rollup.RenderedChunk);
                                 }
                             };
                             collectCssFiles(chunk);
 
                             // Use the relative file name as key. It's used to match the entryPoint passed to `cssLifecycleFactory`.
-                            const cssMapKey = chunk.facadeModuleId!.substring(packageRootDir.length + 1)
+                            const cssMapKey = chunk.facadeModuleId!.substring(packageRootDir.length + 1);
                             cssMap[cssMapKey] = [];
                             for (let css of cssFiles.values()) {
                                 cssMap[cssMapKey].push(css);
@@ -413,7 +413,7 @@ export function pluginFactory(readFileFn?: (path: string, options: any) => Promi
                     for (let x in bundle) {
                         const entry = bundle[x];
                         if (entry.type === 'chunk') {
-                        entry.code = entry.code
+                            entry.code = entry.code
                                 ?.replace('{vpss:PROJECT_ID}', projectId)
                                  .replace(/["`']\{vpss:CSS_MAP\}["`']/, stringifiedCssMap);
                         }

--- a/src/plugin-factory.ts
+++ b/src/plugin-factory.ts
@@ -401,11 +401,8 @@ export function pluginFactory(readFileFn?: (path: string, options: any) => Promi
                             };
                             collectCssFiles(chunk);
 
-                            // By default, use the file name as entry point (cssMap key).
-                            // When specified in the config, use the full path.
-                            const cssMapKey = config.useRelativePathForLifecycleIdentifiers
-                                ? chunk.facadeModuleId!.substring(packageRootDir.length + 1)
-                                : chunk.name;
+                            // Use the relative file name as key. It's used to match the entryPoint passed to `cssLifecycleFactory`.
+                            const cssMapKey = chunk.facadeModuleId!.substring(packageRootDir.length + 1)
                             cssMap[cssMapKey] = [];
                             for (let css of cssFiles.values()) {
                                 cssMap[cssMapKey].push(css);

--- a/src/plugin-factory.ts
+++ b/src/plugin-factory.ts
@@ -77,6 +77,11 @@ export function pluginFactory(readFileFn?: (path: string, options: any) => Promi
          * Control variable used just for logging chunks to a log file.  When true, the title has already been written.
          */
         let chunkInfoTitleWrittenToLog = false;
+        /**
+         * The package's root directory.
+         */
+        let packageRootDir: string;
+
         config.type = config.type ?? 'mife';
         if (isRootConfig(config)) {
             configFn = undefined;
@@ -365,6 +370,9 @@ export function pluginFactory(readFileFn?: (path: string, options: any) => Promi
                     }
                 },
             },
+            configResolved(resolved) {
+                packageRootDir = resolved.root;
+            },
             async generateBundle(_options, bundle, _isWrite) {
                 if (viteEnv.command === 'build') {
                     await closeLog();
@@ -380,21 +388,27 @@ export function pluginFactory(readFileFn?: (path: string, options: any) => Promi
                             const processedImports = new Set<string>();
                             const collectCssFiles = (curChunk: Rollup.RenderedChunk) => {
                                 if (!curChunk) {
-                                    return;
+                                return;
                                 }
                                 curChunk.viteMetadata?.importedCss?.forEach(css => cssFiles.add(css));
                                 for (let imp of curChunk.imports || []) {
-                                    if (processedImports.has(imp)) {
-                                        continue;
-                                    }
-                                    processedImports.add(imp);
+                                if (processedImports.has(imp)) {
+                                    continue;
+                                }
+                                processedImports.add(imp);
                                     collectCssFiles(bundle[imp] as Rollup.RenderedChunk);
                                 }
                             };
                             collectCssFiles(chunk);
-                            cssMap[chunk.name] = [];
+
+                            // By default, use the file name as entry point (cssMap key).
+                            // When specified in the config, use the full path.
+                            const cssMapKey = config.useRelativePathForLifecycleIdentifiers
+                                ? chunk.facadeModuleId!.substring(packageRootDir.length + 1)
+                                : chunk.name;
+                            cssMap[cssMapKey] = [];
                             for (let css of cssFiles.values()) {
-                                cssMap[chunk.name].push(css);
+                                cssMap[cssMapKey].push(css);
                             }
                         }
                     }
@@ -402,7 +416,7 @@ export function pluginFactory(readFileFn?: (path: string, options: any) => Promi
                     for (let x in bundle) {
                         const entry = bundle[x];
                         if (entry.type === 'chunk') {
-                            entry.code = entry.code
+                        entry.code = entry.code
                                 ?.replace('{vpss:PROJECT_ID}', projectId)
                                  .replace(/["`']\{vpss:CSS_MAP\}["`']/, stringifiedCssMap);
                         }

--- a/src/singleMife-css.ts
+++ b/src/singleMife-css.ts
@@ -101,7 +101,8 @@ export function cssLifecycleFactory(entryPoint: string, options?: CssLifecycleFa
         ...options
     };
     setLogger(opts.logger);
-    const cssFiles = cssMap[entryPoint] ?? [];
+    let resolvedEntryPoint = entryPoint.startsWith("./") ? entryPoint.substring(2) : entryPoint;
+    const cssFiles = cssMap[resolvedEntryPoint] ?? [];
     return {
         bootstrap: bootstrap.bind(null, cssFiles),
         mount: mount.bind(null, cssFiles, opts),

--- a/src/singleMife-css.ts
+++ b/src/singleMife-css.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 import { CssLifecycleFactoryOptions } from "vite-plugin-single-spa/ex";
-import { createLinkElement, defaultFactoryOptions, processCssPromises, setLogger, wireCssLinkElement, type LinkLoadResult } from "./css-helpers.js";
+import { createLinkElement, defaultFactoryOptions, getCssFilesForEntrypoint, processCssPromises, setLogger, wireCssLinkElement, type LinkLoadResult } from "./css-helpers.js";
 
 let observer: MutationObserver | undefined;
 let vpssLinkEls: HTMLLinkElement[];
@@ -101,8 +101,7 @@ export function cssLifecycleFactory(entryPoint: string, options?: CssLifecycleFa
         ...options
     };
     setLogger(opts.logger);
-    let resolvedEntryPoint = entryPoint.startsWith("./") ? entryPoint.substring(2) : entryPoint;
-    const cssFiles = cssMap[resolvedEntryPoint] ?? [];
+    const cssFiles = getCssFilesForEntrypoint(entryPoint, cssMap);
     return {
         bootstrap: bootstrap.bind(null, cssFiles),
         mount: mount.bind(null, cssFiles, opts),

--- a/src/vite-plugin-single-spa.d.ts
+++ b/src/vite-plugin-single-spa.d.ts
@@ -100,6 +100,14 @@ declare module "vite-plugin-single-spa" {
          * `vpss(<project id>)<pattern>`.  The plug-in is smart enough to respect any folders in the pattern.
          */
         assetFileNames?: string;
+        /**
+         * When you call `cssLifecycleFactory`, the `entryPoint` you need to specify is the plain filename
+         * without its extension and path.
+         * To prevent collision when exporting multiple entryPoints with the same file name, set this property to true.
+         * So instead of calling `cssLifecycleFactory("myParcel")`, you call `cssLifecycleFactory("path/to/myParcel")`.
+         * @default false
+         */
+        useRelativePathForLifecycleIdentifiers?: boolean;
     } & DebuggingOptions;
 
     /**

--- a/src/vite-plugin-single-spa.d.ts
+++ b/src/vite-plugin-single-spa.d.ts
@@ -100,14 +100,6 @@ declare module "vite-plugin-single-spa" {
          * `vpss(<project id>)<pattern>`.  The plug-in is smart enough to respect any folders in the pattern.
          */
         assetFileNames?: string;
-        /**
-         * When you call `cssLifecycleFactory`, the `entryPoint` you need to specify is the plain filename
-         * without its extension and path.
-         * To prevent collision when exporting multiple entryPoints with the same file name, set this property to true.
-         * So instead of calling `cssLifecycleFactory("myParcel")`, you call `cssLifecycleFactory("path/to/myParcel")`.
-         * @default false
-         */
-        useRelativePathForLifecycleIdentifiers?: boolean;
     } & DebuggingOptions;
 
     /**

--- a/tests/plugin-factory.test.ts
+++ b/tests/plugin-factory.test.ts
@@ -3,11 +3,12 @@ import { expect, it, describe } from "vitest";
 import { pluginFactory } from '../src/plugin-factory.js';
 
 import path from 'path';
-import type { ConfigEnv, HtmlTagDescriptor, Rollup, UserConfig } from 'vite';
+import type { ConfigEnv, HtmlTagDescriptor, MinimalPluginContextWithoutEnvironment, Plugin, ResolvedConfig, Rollup, UserConfig } from 'vite';
 import type { ImoUiOption, ImoUiVariant, ImportMap, ImportMapsOption, SingleSpaMifePluginOptions, SingleSpaRootPluginOptions } from "vite-plugin-single-spa";
 import { cssHelpersModuleName, extensionModuleName } from '../src/ex-defs.js';
 
 type ConfigHandler = (this: void, config: UserConfig, env: ConfigEnv) => Promise<UserConfig>
+type ConfigResolvedHandler = (this: void, config: Partial<ResolvedConfig>) => void | Promise<void>;
 type ResolveIdHandler = (this: void, source: string) => string;
 type LoadHandler = (this: void, id: string) => Promise<string>;
 type RenderChunkHandler = { handler: (this: void, code: string, chunk: Rollup.RenderedChunk, options: Record<any, any>, meta: { chunks: Record<string, Rollup.RenderedChunk> }) => Promise<any> };
@@ -23,6 +24,7 @@ type TestRenderedChunk = {
     isEntry: boolean;
     imports: string[];
     viteMetadata?: TestChunkMetadata;
+    facadeModuleId: string;
 };
 
 const viteCommands: ConfigEnv['command'][] = [
@@ -515,7 +517,12 @@ describe('vite-plugin-single-spa', () => {
             // Assert.
             expect(caughtError).to.equal(false);
         });
-        const cssMapInsertionTest = async (chunks: TestRenderedChunk[], expectedMap: Record<string, string[]>, cssPlaceholderStr: string) => {
+        const cssMapInsertionTest = async (
+                chunks: TestRenderedChunk[],
+                expectedMap: Record<string, string[]>,
+                cssPlaceholderStr: string,
+                useRelativePathForLifecycleIdentifiers: boolean
+            ) => {
             // Arrange.
             const readFile = (fileName: string, _opts: any) => {
                 if (fileName !== './package.json') {
@@ -523,7 +530,7 @@ describe('vite-plugin-single-spa', () => {
                 }
                 return Promise.resolve(JSON.stringify(pkgJson));
             };
-            const plugIn = pluginFactory(readFile)({ serverPort: 4444 });
+            const plugIn = pluginFactory(readFile)({ serverPort: 4444, useRelativePathForLifecycleIdentifiers });
             const env: ConfigEnv = { command: 'build', mode: 'production' };
             const meta: { chunks: Record<string, Rollup.RenderedChunk> } = {
                 chunks: {}
@@ -532,6 +539,7 @@ describe('vite-plugin-single-spa', () => {
                 meta.chunks[ch.fileName] = ch as Rollup.RenderedChunk;
             }
             await (plugIn.config as ConfigHandler)({}, env);
+            await (plugIn.configResolved as ConfigResolvedHandler)({root: "/path/to/package"});
             for (let ch of chunks) {
                 await (plugIn.renderChunk as RenderChunkHandler).handler('', ch as Rollup.RenderedChunk, {}, meta);
             }
@@ -556,7 +564,19 @@ describe('vite-plugin-single-spa', () => {
 
             // Assert.
             const calculatedCssMap = JSON.parse(JSON.parse(bundle['a.js'].code));
-            expect(calculatedCssMap).to.deep.equal(expectedMap);
+            if (!useRelativePathForLifecycleIdentifiers) {
+                expect(calculatedCssMap).to.deep.equal(expectedMap);
+            } else {
+                // Add relative path and extension to expected entry points.
+                const expectedMapWithPathEntrypoints = Object.fromEntries(
+                    Object.entries(expectedMap).map(([entryPoint, fileNames]) => [
+                        `spa/${entryPoint}.js`,
+                        fileNames,
+                    ]),
+                );
+                expect(calculatedCssMap).to.deep.equal(expectedMapWithPathEntrypoints);
+
+            }
         };
         const buildSet = (items?: string[]) => new Set(items);
         const cssMapInsertionTestData: { chunks: TestRenderedChunk[]; text: string; expectedMap: Record<string, string[]>; }[] = [
@@ -565,6 +585,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'A',
                         fileName: 'A.js',
+                        facadeModuleId: '/path/to/package/spa/A.js',
                         isEntry: true,
                         imports: [],
                         viteMetadata: {
@@ -583,6 +604,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'A',
                         fileName: 'A.js',
+                        facadeModuleId: '/path/to/package/spa/A.js',
                         isEntry: true,
                         imports: ['b.js'],
                         viteMetadata: {
@@ -593,6 +615,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'b',
                         fileName: 'b.js',
+                        facadeModuleId: '/path/to/package/spa/b.js',
                         isEntry: false,
                         imports: [],
                         viteMetadata: {
@@ -611,6 +634,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'A',
                         fileName: 'A.js',
+                        facadeModuleId: '/path/to/package/spa/A.js',
                         isEntry: true,
                         imports: ['b.js', 'c.js'],
                         viteMetadata: {
@@ -621,6 +645,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'b',
                         fileName: 'b.js',
+                        facadeModuleId: '/path/to/package/spa/b.js',
                         isEntry: false,
                         imports: [],
                         viteMetadata: {
@@ -631,6 +656,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'c',
                         fileName: 'c.js',
+                        facadeModuleId: '/path/to/package/spa/c.js',
                         isEntry: false,
                         imports: [],
                         viteMetadata: {
@@ -649,6 +675,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'A',
                         fileName: 'A.js',
+                        facadeModuleId: '/path/to/package/spa/A.js',
                         isEntry: true,
                         imports: ['b.js', 'c.js'],
                         viteMetadata: {
@@ -659,6 +686,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'b',
                         fileName: 'b.js',
+                        facadeModuleId: '/path/to/package/spa/b.js',
                         isEntry: false,
                         imports: [],
                         viteMetadata: {
@@ -669,6 +697,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'c',
                         fileName: 'c.js',
+                        facadeModuleId: '/path/to/package/spa/c.js',
                         isEntry: false,
                         imports: [],
                         viteMetadata: {
@@ -687,6 +716,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'A',
                         fileName: 'A.js',
+                        facadeModuleId: '/path/to/package/spa/A.js',
                         isEntry: true,
                         imports: ['b.js', 'c.js'],
                         viteMetadata: {
@@ -696,6 +726,7 @@ describe('vite-plugin-single-spa', () => {
                     },
                     {
                         name: 'b',
+                        facadeModuleId: '/path/to/package/spa/b.js',
                         fileName: 'b.js',
                         isEntry: false,
                         imports: ['c.js'],
@@ -707,6 +738,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'c',
                         fileName: 'c.js',
+                        facadeModuleId: '/path/to/package/spa/c.js',
                         isEntry: false,
                         imports: [],
                         viteMetadata: {
@@ -725,6 +757,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'A',
                         fileName: 'A.js',
+                        facadeModuleId: '/path/to/package/spa/A.js',
                         isEntry: true,
                         imports: ['b.js', 'c.js'],
                         viteMetadata: {
@@ -735,6 +768,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'b',
                         fileName: 'b.js',
+                        facadeModuleId: '/path/to/package/spa/b.js',
                         isEntry: false,
                         imports: [],
                         viteMetadata: {
@@ -745,6 +779,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'c',
                         fileName: 'c.js',
+                        facadeModuleId: '/path/to/package/spa/c.js',
                         isEntry: false,
                         imports: [],
                         viteMetadata: {
@@ -755,6 +790,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'd',
                         fileName: 'd.js',
+                        facadeModuleId: '/path/to/package/spa/d.js',
                         isEntry: false,
                         imports: ['c.js'],
                         viteMetadata: {
@@ -773,6 +809,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'A',
                         fileName: 'A.js',
+                        facadeModuleId: '/path/to/package/spa/A.js',
                         isEntry: true,
                         imports: ['b.js', 'c.js'],
                         viteMetadata: {
@@ -783,6 +820,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'b',
                         fileName: 'b.js',
+                        facadeModuleId: '/path/to/package/spa/b.js',
                         isEntry: false,
                         imports: [],
                         viteMetadata: {
@@ -793,6 +831,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'c',
                         fileName: 'c.js',
+                        facadeModuleId: '/path/to/package/spa/c.js',
                         isEntry: false,
                         imports: [],
                         viteMetadata: {
@@ -803,6 +842,7 @@ describe('vite-plugin-single-spa', () => {
                     {
                         name: 'P',
                         fileName: 'P.js',
+                        facadeModuleId: '/path/to/package/spa/P.js',
                         isEntry: true,
                         imports: ['c.js'],
                         viteMetadata: {
@@ -820,12 +860,16 @@ describe('vite-plugin-single-spa', () => {
         ];
         for (let tc of cssMapInsertionTestData) {
             for (let cssPlaceholderStr of ["'{vpss:CSS_MAP}'", "`{vpss:CSS_MAP}`", '"{vpss:CSS_MAP}"']) {
+                // With filenames as entry points
                 it(`Should insert the stringified CSS Map in chunks that need it: ${tc.text}; CSS_MAP placeholder: ${cssPlaceholderStr}`,
-                    () => cssMapInsertionTest(tc.chunks, tc.expectedMap, cssPlaceholderStr));
+                    () => cssMapInsertionTest(tc.chunks, tc.expectedMap, cssPlaceholderStr, false));
+                // With paths as entry points
+                it(`Should insert the stringified CSS Map in chunks that need it: ${tc.text}; CSS_MAP placeholder: ${cssPlaceholderStr}`,
+                    () => cssMapInsertionTest(tc.chunks, tc.expectedMap, cssPlaceholderStr, true));
             }
             for (let cssInvalidPlaceholderStr of ["<{vpss:CSS_MAP}>", "{vpss:CSS_MAP}"]) {
                 it.fails(`Should not insert the stringified CSS Map in chunks with an invalid placeholder: ${tc.text}; CSS_MAP placeholder: ${cssInvalidPlaceholderStr}`,
-                    () => cssMapInsertionTest(tc.chunks, tc.expectedMap, cssInvalidPlaceholderStr));
+                    () => cssMapInsertionTest(tc.chunks, tc.expectedMap, cssInvalidPlaceholderStr, false));
             }
         }
         it("Should insert the package's name in the chunks that require it.", async () => {

--- a/tests/plugin-factory.test.ts
+++ b/tests/plugin-factory.test.ts
@@ -1,7 +1,7 @@
 /// <reference path="../src/vite-plugin-single-spa.d.ts"/>
 import { expect, it, describe } from "vitest";
 import { pluginFactory } from '../src/plugin-factory.js';
-
+import {getCssFilesForEntrypoint} from "../src/css-helpers.js"
 import path from 'path';
 import type { ConfigEnv, HtmlTagDescriptor, MinimalPluginContextWithoutEnvironment, Plugin, ResolvedConfig, Rollup, UserConfig } from 'vite';
 import type { ImoUiOption, ImoUiVariant, ImportMap, ImportMapsOption, SingleSpaMifePluginOptions, SingleSpaRootPluginOptions } from "vite-plugin-single-spa";
@@ -520,8 +520,7 @@ describe('vite-plugin-single-spa', () => {
         const cssMapInsertionTest = async (
                 chunks: TestRenderedChunk[],
                 expectedMap: Record<string, string[]>,
-                cssPlaceholderStr: string,
-                useRelativePathForLifecycleIdentifiers: boolean
+                cssPlaceholderStr: string
             ) => {
             // Arrange.
             const readFile = (fileName: string, _opts: any) => {
@@ -530,7 +529,7 @@ describe('vite-plugin-single-spa', () => {
                 }
                 return Promise.resolve(JSON.stringify(pkgJson));
             };
-            const plugIn = pluginFactory(readFile)({ serverPort: 4444, useRelativePathForLifecycleIdentifiers });
+            const plugIn = pluginFactory(readFile)({ serverPort: 4444 });
             const env: ConfigEnv = { command: 'build', mode: 'production' };
             const meta: { chunks: Record<string, Rollup.RenderedChunk> } = {
                 chunks: {}
@@ -564,19 +563,7 @@ describe('vite-plugin-single-spa', () => {
 
             // Assert.
             const calculatedCssMap = JSON.parse(JSON.parse(bundle['a.js'].code));
-            if (!useRelativePathForLifecycleIdentifiers) {
-                expect(calculatedCssMap).to.deep.equal(expectedMap);
-            } else {
-                // Add relative path and extension to expected entry points.
-                const expectedMapWithPathEntrypoints = Object.fromEntries(
-                    Object.entries(expectedMap).map(([entryPoint, fileNames]) => [
-                        `spa/${entryPoint}.js`,
-                        fileNames,
-                    ]),
-                );
-                expect(calculatedCssMap).to.deep.equal(expectedMapWithPathEntrypoints);
-
-            }
+            expect(calculatedCssMap).to.deep.equal(expectedMap);
         };
         const buildSet = (items?: string[]) => new Set(items);
         const cssMapInsertionTestData: { chunks: TestRenderedChunk[]; text: string; expectedMap: Record<string, string[]>; }[] = [
@@ -596,7 +583,7 @@ describe('vite-plugin-single-spa', () => {
                 ],
                 text: 'A[1]:  a',
                 expectedMap: {
-                    'A': ['A.css']
+                    'spa/A.js': ['A.css']
                 }
             },
             {
@@ -626,7 +613,7 @@ describe('vite-plugin-single-spa', () => {
                 ],
                 text: 'A, b[1]:  A->b',
                 expectedMap: {
-                    'A': ['b.css']
+                    'spa/A.js': ['b.css']
                 }
             },
             {
@@ -667,7 +654,7 @@ describe('vite-plugin-single-spa', () => {
                 ],
                 text: 'A, b[1], c[1]:  A->bc',
                 expectedMap: {
-                    'A': ['b.css', 'c.css']
+                    'spa/A.js': ['b.css', 'c.css']
                 }
             },
             {
@@ -708,7 +695,7 @@ describe('vite-plugin-single-spa', () => {
                 ],
                 text: 'A[1], b[1], c[1]:  A->bc',
                 expectedMap: {
-                    'A': ['A.css', 'b.css', 'c.css']
+                    'spa/A.js': ['A.css', 'b.css', 'c.css']
                 }
             },
             {
@@ -749,7 +736,7 @@ describe('vite-plugin-single-spa', () => {
                 ],
                 text: 'A[1], b[1], c[1]:  A->bc, b->c',
                 expectedMap: {
-                    'A': ['A.css', 'b.css', 'c.css']
+                    'spa/A.js': ['A.css', 'b.css', 'c.css']
                 }
             },
             {
@@ -801,7 +788,7 @@ describe('vite-plugin-single-spa', () => {
                 ],
                 text: 'A[1], b[1], c[1], d[1]:  A->bc',
                 expectedMap: {
-                    'A': ['A.css', 'b.css', 'c.css']
+                    'spa/A.js': ['A.css', 'b.css', 'c.css']
                 }
             },
             {
@@ -853,8 +840,8 @@ describe('vite-plugin-single-spa', () => {
                 ],
                 text: 'A[1], b[1], c[1], P[1]:  A->bc, P->c',
                 expectedMap: {
-                    'A': ['A.css', 'b.css', 'c.css'],
-                    'P': ['P.css', 'c.css']
+                    'spa/A.js': ['A.css', 'b.css', 'c.css'],
+                    'spa/P.js': ['P.css', 'c.css']
                 }
             },
         ];
@@ -862,14 +849,11 @@ describe('vite-plugin-single-spa', () => {
             for (let cssPlaceholderStr of ["'{vpss:CSS_MAP}'", "`{vpss:CSS_MAP}`", '"{vpss:CSS_MAP}"']) {
                 // With filenames as entry points
                 it(`Should insert the stringified CSS Map in chunks that need it: ${tc.text}; CSS_MAP placeholder: ${cssPlaceholderStr}`,
-                    () => cssMapInsertionTest(tc.chunks, tc.expectedMap, cssPlaceholderStr, false));
-                // With paths as entry points
-                it(`Should insert the stringified CSS Map in chunks that need it: ${tc.text}; CSS_MAP placeholder: ${cssPlaceholderStr}`,
-                    () => cssMapInsertionTest(tc.chunks, tc.expectedMap, cssPlaceholderStr, true));
+                    () => cssMapInsertionTest(tc.chunks, tc.expectedMap, cssPlaceholderStr));
             }
             for (let cssInvalidPlaceholderStr of ["<{vpss:CSS_MAP}>", "{vpss:CSS_MAP}"]) {
                 it.fails(`Should not insert the stringified CSS Map in chunks with an invalid placeholder: ${tc.text}; CSS_MAP placeholder: ${cssInvalidPlaceholderStr}`,
-                    () => cssMapInsertionTest(tc.chunks, tc.expectedMap, cssInvalidPlaceholderStr, false));
+                    () => cssMapInsertionTest(tc.chunks, tc.expectedMap, cssInvalidPlaceholderStr));
             }
         }
         it("Should insert the package's name in the chunks that require it.", async () => {
@@ -968,6 +952,17 @@ describe('vite-plugin-single-spa', () => {
         for (let tc of spaEntryPointsTestData) {
             it(`Should add the specified entry points as inputs for rollup build.  Inputs: ${tc.inputs}`, () => spaEntryPointsTest(tc.expects, tc.inputs));
         }
+        it("Should resolve the createCssLifecycles entryPoints by path and file name", () => {
+            const cssMap = {
+                "src/spa/parcel1.tsx": ["spa1-parcel1.css"],
+                "src/spa/parcel2.tsx": ["spa1-parcel2.css"],
+                "src/spa2/parcel1.tsx": ["spa2-parcel1.css"]
+            };
+            expect(getCssFilesForEntrypoint("./src/spa/parcel1.tsx", cssMap)).toEqual(["spa1-parcel1.css"]);
+            expect(getCssFilesForEntrypoint("src/spa2/parcel1.tsx", cssMap)).toEqual(["spa2-parcel1.css"]);
+            expect(getCssFilesForEntrypoint("parcel2", cssMap)).toEqual(["spa1-parcel2.css"]);
+            expect(() => getCssFilesForEntrypoint("parcel1", cssMap)).toThrow()
+        });
     });
     describe('Root Configuration', () => {
         const configTest = async (viteCmd: ConfigEnv['command']) => {


### PR DESCRIPTION
Up to now it was not possible to have more than one entry point with the same file name, since it was breaking the correct loading of CSS files with `cssLifecycleFactory`.
This PR adds the option to call `cssLifecycleFactory` with an entry point as a path. E.g. `cssLifecycleFactory("src/spa/component.tsx")`.
To activate the feature, you need to add the option `useRelativePathForLifecycleIdentifiers` when calling `vitePluginSingleSpa()` in your vite config. It's behind that flag to enable backward compatibility.