### PR TITLE
fix: Select no-css.js for root config projects to cover cases where `viteEnv` is used

### DIFF
--- a/src/plugin-factory.ts
+++ b/src/plugin-factory.ts
@@ -299,7 +299,7 @@ export function pluginFactory(readFileFn?: (path: string, options: any) => Promi
             name: 'vite-plugin-single-spa',
             async config(cfg, opts) {
                 viteEnv = opts;
-                cssModuleFileName = viteEnv.command !== 'build' || (config as SingleSpaMifePluginOptions).cssStrategy === 'none' ?
+                cssModuleFileName = viteEnv.command !== 'build' || (config as SingleSpaMifePluginOptions).cssStrategy === 'none' || isRootConfig(config) ?
                     'no-css.js' :
                     `${(config as SingleSpaMifePluginOptions).cssStrategy ?? 'singleMife'}-css.js`;
                 if (lg?.incomingConfig) {


### PR DESCRIPTION
if root, it should not have any css injection.
Currently it uses the singleMife-css.js, which is injected without replacing the placeholders (because of line 372) which then results in an error and a blank window when running it after build.